### PR TITLE
#dynamic library builds on OSX Yosemite with clang 

### DIFF
--- a/api/Monosat.cpp
+++ b/api/Monosat.cpp
@@ -170,10 +170,8 @@ void _selectAlgorithms(){
 }
 void printStats(SimpSolver* solver) {
 	double cpu_time = cpuTime();
-
     double mem_used = memUsedPeak(); // not available in osx
 
-    
 	solver->printStats(3);
 	if (mem_used != 0)
 		printf("Memory used           : %.2f MB\n", mem_used);

--- a/api/Monosat.cpp
+++ b/api/Monosat.cpp
@@ -170,7 +170,13 @@ void _selectAlgorithms(){
 }
 void printStats(SimpSolver* solver) {
 	double cpu_time = cpuTime();
-	double mem_used = memUsedPeak();
+    
+#if defined(__APPLE__)
+    double mem_used = 0;
+#else
+    double mem_used = memUsedPeak(); // not available in osx
+#endif
+    
 	solver->printStats(3);
 	if (mem_used != 0)
 		printf("Memory used           : %.2f MB\n", mem_used);

--- a/api/Monosat.cpp
+++ b/api/Monosat.cpp
@@ -170,12 +170,9 @@ void _selectAlgorithms(){
 }
 void printStats(SimpSolver* solver) {
 	double cpu_time = cpuTime();
-    
-#if defined(__APPLE__)
-    double mem_used = 0;
-#else
+
     double mem_used = memUsedPeak(); // not available in osx
-#endif
+
     
 	solver->printStats(3);
 	if (mem_used != 0)

--- a/bv/BVTheorySolver.h
+++ b/bv/BVTheorySolver.h
@@ -418,7 +418,7 @@ public:
 	void printStats(int detailLevel) {
 		printf("BV Theory %d stats:\n", this->getTheoryIndex());
 
-		printf("%d bitvectors, %ld bits, %l comparisons (bvcomparisons %d), %ld additions\n", bitvectors.size(),n_bits,compares.size()+bvcompares.size(),bvcompares.size(), n_additions				 );
+		printf("%d bitvectors, %ld bits, %d comparisons (bvcomparisons %d), %ld additions\n", bitvectors.size(),n_bits,compares.size()+bvcompares.size(),bvcompares.size(), n_additions				 );
 		printf("constant bitvectors (at start, end of deduction): %ld, %ld\n",n_starting_consts ,n_consts);
 
 
@@ -2321,7 +2321,7 @@ public:
 					double startconftime = rtime(2);
 					stats_num_conflicts++;
 					if(opt_verb>1){
-						printf("bv approximation update conflict %d\n", stats_num_conflicts);
+						printf("bv approximation update conflict %ld\n", stats_num_conflicts);
 					}
 					propagationtime += startconftime - startproptime;
 					//this is already a conflict;
@@ -2358,7 +2358,7 @@ public:
 								}
 								stats_num_conflicts++;stats_bit_conflicts++;
 								if(opt_verb>1){
-									printf("bv bit conflict %d\n", stats_num_conflicts);
+									printf("bv bit conflict %ld\n", stats_num_conflicts);
 								}
 								buildComparisonReason(Comparison::leq,bvID,overApprox,conflict);
 								toSolver(conflict);
@@ -2383,7 +2383,7 @@ public:
 								}
 								stats_num_conflicts++;stats_bit_conflicts++;
 								if(opt_verb>1){
-									printf("bv bit conflict %d\n", stats_num_conflicts);
+									printf("bv bit conflict %ld\n", stats_num_conflicts);
 								}
 								buildComparisonReason(Comparison::geq,bvID,underApprox,conflict);
 								toSolver(conflict);
@@ -2428,7 +2428,7 @@ public:
 					propagationtime += startconftime - startproptime;
 					stats_num_conflicts++;stats_addition_conflicts++;
 					if(opt_verb>1){
-						printf("bv addition conflict %d\n", stats_num_conflicts);
+						printf("bv addition conflict %ld\n", stats_num_conflicts);
 					}
 					buildAdditionReason(bvID,i,conflict);
 					toSolver(conflict);
@@ -2438,7 +2438,7 @@ public:
 					double startconftime = rtime(2);
 					propagationtime += startconftime - startproptime;
 					if(opt_verb>1){
-						printf("bv addition conflict %d\n", stats_num_conflicts);
+						printf("bv addition conflict %ld\n", stats_num_conflicts);
 					}
 					stats_num_conflicts++;stats_addition_conflicts++;
 					buildAdditionReason(bvID,i,conflict);
@@ -2498,7 +2498,7 @@ public:
 						int a=1;
 					}
 					if(opt_verb>1){
-						printf("bv addition arg conflict %d\n", stats_num_conflicts);
+						printf("bv addition arg conflict %ld\n", stats_num_conflicts);
 					}
 					buildAdditionArgReason(bvID,i,conflict);
 					toSolver(conflict);
@@ -2509,7 +2509,7 @@ public:
 					propagationtime += startconftime - startproptime;
 					stats_num_conflicts++;stats_addition_conflicts++;
 					if(opt_verb>1){
-						printf("bv addition arg conflict %d\n", stats_num_conflicts);
+						printf("bv addition arg conflict %ld\n", stats_num_conflicts);
 					}
 					buildAdditionArgReason(bvID,i,conflict);
 					toSolver(conflict);
@@ -2573,7 +2573,7 @@ public:
 						propagationtime += startconftime - startproptime;
 						stats_num_conflicts++;stats_compare_conflicts++;
 						if(opt_verb>1){
-							printf("bv comparison conflict %d\n", stats_num_conflicts);
+							printf("bv comparison conflict %ld\n", stats_num_conflicts);
 						}
 						assert(value(l)==l_False);
 						assert(dbg_value(l)==l_False);
@@ -2593,7 +2593,7 @@ public:
 						propagationtime += startconftime - startproptime;
 						stats_num_conflicts++;stats_compare_conflicts++;
 						if(opt_verb>1){
-							printf("bv comparison conflict %d\n", stats_num_conflicts);
+							printf("bv comparison conflict %ld\n", stats_num_conflicts);
 						}
 						conflict.push(~l);
 						buildComparisonReason(-op,bvID,to,conflict);
@@ -2625,7 +2625,7 @@ public:
 						propagationtime += startconftime - startproptime;
 						stats_num_conflicts++;stats_compare_conflicts++;
 						if(opt_verb>1){
-							printf("bv comparison conflict %d\n", stats_num_conflicts);
+							printf("bv comparison conflict %ld\n", stats_num_conflicts);
 						}
 						conflict.push(~l);
 						buildComparisonReason(-op,bvID,to,conflict);
@@ -2648,7 +2648,7 @@ public:
 						propagationtime += startconftime - startproptime;
 						stats_num_conflicts++;stats_compare_conflicts++;
 						if(opt_verb>1){
-							printf("bv comparison conflict %d\n", stats_num_conflicts);
+							printf("bv comparison conflict %ld\n", stats_num_conflicts);
 						}
 						conflict.push(l);
 						buildComparisonReason(op,bvID,to,conflict);
@@ -2705,7 +2705,7 @@ public:
 						propagationtime += startconftime - startproptime;
 						stats_num_conflicts++;stats_bv_compare_conflicts++;
 						if(opt_verb>1){
-							printf("bv bv comparison conflict %d\n", stats_num_conflicts);
+							printf("bv bv comparison conflict %ld\n", stats_num_conflicts);
 						}
 						conflict.push(~l);
 						buildComparisonReasonBV(-op,bvID,compareID,conflict);
@@ -2756,7 +2756,7 @@ public:
 						propagationtime += startconftime - startproptime;
 						stats_num_conflicts++;stats_bv_compare_conflicts++;
 						if(opt_verb>1){
-							printf("bv bv comparison conflict %d\n", stats_num_conflicts);
+							printf("bv bv comparison conflict %ld\n", stats_num_conflicts);
 						}
 						conflict.push(~l);
 						buildComparisonReasonBV(-op,bvID,compareID,conflict);
@@ -4810,17 +4810,21 @@ template<typename Weight>
 
 template<>
 inline mpq_class BVTheorySolver<mpq_class>::refine_ubound_check(int bvID, mpq_class bound, Var ignore_bit){
+    exit(1);
 }
 template<>
 inline double BVTheorySolver<double>::refine_ubound_check(int bvID, double bound, Var ignore_bit){
+    exit(1);
 }
 
 
 template<>
 inline mpq_class BVTheorySolver<mpq_class>::refine_lbound_check(int bvID, mpq_class bound, Var ignore_bit){
+    exit(1);
 }
 template<>
 inline double BVTheorySolver<double>::refine_lbound_check(int bvID, double bound, Var ignore_bit){
+    exit(1);
 }
 
 template<>

--- a/core/Solver.cc
+++ b/core/Solver.cc
@@ -1552,7 +1552,7 @@ bool Solver::addConflictClause(vec<Lit> & ps, CRef & confl_out, bool permanent) 
 					max_learnts *= learntsize_inc;
 					
 					if (verbosity >= 1)
-						printf("| %9d | %7d %8d %8d | %8d %8d %6.0f | %ld removed |\n", (int) conflicts,
+						printf("| %9d | %7d %8d %8d | %8d %8d %6.0f | %" PRId64 " removed |\n", (int) conflicts,
 								(int) dec_vars - (trail_lim.size() == 0 ? trail.size() : trail_lim[0]), nClauses(),
 								(int) clauses_literals, (int) max_learnts, nLearnts(),
 								(double) learnts_literals / nLearnts(), stats_removed_clauses);
@@ -1683,7 +1683,7 @@ lbool Solver::search(int nof_conflicts) {
 				max_learnts *= learntsize_inc;
 				
 				if (verbosity >= 1)
-					printf("| %9d | %7d %8d %8d | %8d %8d %6.0f | %ld removed |\n", (int) conflicts,
+					printf("| %9d | %7d %8d %8d | %8d %8d %6.0f | %" PRId64 " removed |\n", (int) conflicts,
 							(int) dec_vars - (trail_lim.size() == 0 ? trail.size() : trail_lim[0]), nClauses(),
 							(int) clauses_literals, (int) max_learnts, nLearnts(),
 							(double) learnts_literals / nLearnts(), stats_removed_clauses);

--- a/core/Solver.h
+++ b/core/Solver.h
@@ -33,6 +33,7 @@
 #include "core/Theory.h"
 #include "core/TheorySolver.h"
 #include "core/Config.h"
+#include <cinttypes>
 
 //this is _really_ ugly...
 template<unsigned int D, class T> class GeometryTheorySolver;
@@ -160,22 +161,28 @@ public:
 	}
 	
 	void printStats(int detail_level = 0) {
-		double cpu_time = cpuTime();
-		double mem_used = memUsedPeak();
-		
+        
+        double cpu_time = cpuTime();
+
+#if defined(__APPLE__)
+        double mem_used = 0;
+#else
+        double mem_used = memUsedPeak(); // not available in osx
+#endif
+        
 		printf("restarts              : %" PRIu64 "\n", starts);
-		printf("conflicts             : %-12" PRIu64 "   (%.0f /sec, %d learnts, %ld removed)\n", conflicts,
+		printf("conflicts             : %-12" PRIu64 "   (%.0f /sec, %d learnts, %" PRId64 " removed)\n", conflicts,
 				conflicts / cpu_time, learnts.size(), stats_removed_clauses);
 		printf("decisions             : %-12" PRIu64 "   (%4.2f %% random) (%.0f /sec)\n", decisions,
 				(float) rnd_decisions * 100 / (float) decisions, decisions / cpu_time);
 		if(opt_decide_theories){
-		printf("Theory decision rounds: %ld/%ld\n",n_theory_decision_rounds,starts);
+		printf("Theory decision rounds: %" PRId64 "/%" PRId64 "\n",n_theory_decision_rounds,starts);
 		}
 		printf("propagations          : %-12" PRIu64 "   (%.0f /sec)\n", propagations, propagations / cpu_time);
 		printf("conflict literals     : %-12" PRIu64 "   (%4.2f %% deleted)\n", tot_literals,
 				(max_literals - tot_literals) * 100 / (double) max_literals);
 		if (opt_detect_pure_theory_lits) {
-			printf("pure literals     : %ld (%ld theory lits) (%ld rounds, %f time)\n", stats_pure_lits,
+			printf("pure literals     : %" PRId64 " (%" PRId64 " theory lits) (%" PRId64 " rounds, %f time)\n", stats_pure_lits,
 					stats_pure_theory_lits, pure_literal_detections, stats_pure_lit_time);
 		}
 

--- a/core/Solver.h
+++ b/core/Solver.h
@@ -163,7 +163,6 @@ public:
 	void printStats(int detail_level = 0) {
         
         double cpu_time = cpuTime();
-
         double mem_used = memUsedPeak(); // not available in osx
 
         

--- a/core/Solver.h
+++ b/core/Solver.h
@@ -164,11 +164,8 @@ public:
         
         double cpu_time = cpuTime();
 
-#if defined(__APPLE__)
-        double mem_used = 0;
-#else
         double mem_used = memUsedPeak(); // not available in osx
-#endif
+
         
 		printf("restarts              : %" PRIu64 "\n", starts);
 		printf("conflicts             : %-12" PRIu64 "   (%.0f /sec, %d learnts, %" PRId64 " removed)\n", conflicts,

--- a/dgl/alg/LinkCutCost.h
+++ b/dgl/alg/LinkCutCost.h
@@ -26,6 +26,7 @@
 #include <cassert>
 #include <iostream>
 #include <algorithm>
+#include <vector>
 
 
 #ifdef NDEBUG

--- a/fsm/FSMAcceptDetector.h
+++ b/fsm/FSMAcceptDetector.h
@@ -128,7 +128,7 @@ public:
 			int node = accept_lit_map[index].to;
 			int str =  accept_lit_map[index].str;
 			//if (!is_changed[index]) {
-				changed.push( { var(l), node,str });
+            changed.push( { {var(l)}, node,str });
 			//	is_changed[index] = true;
 			//}
 		}

--- a/fsm/FSMGeneratesDetector.h
+++ b/fsm/FSMGeneratesDetector.h
@@ -126,7 +126,7 @@ public:
 
 			int str =  generate_lit_map[index].str;
 			//if (!is_changed[index]) {
-				changed.push( { var(l), str });
+            changed.push( { {var(l)}, str });
 			//	is_changed[index] = true;
 			//}
 		}

--- a/fsm/FSMGeneratorAcceptorDetector.cpp
+++ b/fsm/FSMGeneratorAcceptorDetector.cpp
@@ -354,7 +354,7 @@ void FSMGeneratorAcceptorDetector::addAcceptLit(int generatorFinalState, int acc
 	lit_backward_map[generatorFinalState + acceptorFinalState*g_over.states()]= var(acceptLit);
 
 	while (accept_lit_map.size() <= accept_var - first_var) {
-		accept_lit_map.push({-1,-1});
+        accept_lit_map.push({{-1},-1});
 	}
 	accept_lit_map[accept_var - first_var] = {acceptLit,generatorFinalState,acceptorFinalState};
 	all_accept_lits.push( {acceptLit,generatorFinalState,acceptorFinalState});

--- a/fsm/FSMTransducesDetector.h
+++ b/fsm/FSMTransducesDetector.h
@@ -141,7 +141,7 @@ public:
 			int str1 =  accept_lit_map[index].str1;
 			int str2 =  accept_lit_map[index].str2;
 			//if (!is_changed[index]) {
-				changed.push( { var(l), node,str1,str2 });
+            changed.push( { {var(l)}, node,str1,str2 });
 			//	is_changed[index] = true;
 			//}
 		}

--- a/fsm/P0LAcceptDetector.h
+++ b/fsm/P0LAcceptDetector.h
@@ -121,7 +121,7 @@ public:
 
 			int str =  accept_lit_map[index].str;
 			//if (!is_changed[index]) {
-				changed.push( { var(l), str });
+            changed.push( { {var(l)}, str });
 			//	is_changed[index] = true;
 			//}
 		}

--- a/graph/Detector.h
+++ b/graph/Detector.h
@@ -75,7 +75,7 @@ public:
 			printf("\tOver-approx updates: %ld (%ld skipped)  (%f s total, %f s avg)\n", stats_over_updates,
 					stats_skipped_over_updates, (double) stats_over_update_time,
 					(double) stats_over_update_time / (double) (stats_over_updates + 1));
-			printf("\tTheory Decisions: %ld (%f s total, %f s avg, %d priority)\n", stats_decisions, (double) stats_decide_time,
+			printf("\tTheory Decisions: %ld (%f s total, %f s avg, %ld priority)\n", stats_decisions, (double) stats_decide_time,
 					(double) stats_decide_time / (double) (stats_decisions + 1),n_stats_priority_decisions);
 			printf(
 					"\tConflicts (under,over): %ld (clause literals: %ld), %ld, (clause literals: %ld), (under time %f s, over time %f s)\n",

--- a/graph/GraphTheory.h
+++ b/graph/GraphTheory.h
@@ -706,7 +706,7 @@ public:
 				(propagationtime) / ((double) stats_propagations + 1), stats_propagations_skipped);
 		printf("Decisions: %ld (%f s, avg: %f s), lazy decisions: %ld\n", stats_decisions, stats_decision_time,
 				(stats_decision_time) / ((double) stats_decisions + 1), stats_lazy_decisions);
-		printf("Conflicts: %ld (lazy conflicts %d)\n", stats_num_conflicts,stats_num_lazy_conflicts);
+		printf("Conflicts: %ld (lazy conflicts %ld)\n", stats_num_conflicts,stats_num_lazy_conflicts);
 		printf("Reasons: %ld (%f s, avg: %f s)\n", stats_num_reasons, stats_reason_time,
 				(stats_reason_time) / ((double) stats_num_reasons + 1));
 

--- a/utils/System.cc
+++ b/utils/System.cc
@@ -89,7 +89,7 @@ double Monosat::memUsed(void) {
 	malloc_statistics_t t;
 	malloc_zone_statistics(NULL, &t);
 	return (double)t.max_size_in_use / (1024*1024);}
-double Monosat::memUsedPeak(void) {return memUsed(); }
+    double Monosat::memUsedPeak(void) {return memUsed(); }
 #else
 double Monosat::memUsed() {
 	return 0;}

--- a/utils/System.cc
+++ b/utils/System.cc
@@ -89,7 +89,7 @@ double Monosat::memUsed(void) {
 	malloc_statistics_t t;
 	malloc_zone_statistics(NULL, &t);
 	return (double)t.max_size_in_use / (1024*1024);}
-
+double Monosat::memUsedPeak(void) {return memUsed(); }
 #else
 double Monosat::memUsed() {
 	return 0;}


### PR DESCRIPTION
Hi 

I built this on OSX Yosemite with clang and got lots of warnings and a couple of small errors.

The warnings where pretty much all printf format errors using %d instead of %ld where a long was used.

The errors where a missing header file <vector> and a couple of conditional compilations around memUsedPeak() which doesnt exist on osx so the print stats methods in the solver will print 0 on OSX but work as before elsewhere.

There are now still 7 warnings but I have not yet decided the best way to solve them. They are hidden virtual function warnings.

Regards

Eric
