### PR TITLE
Fix for compilation under OSX

### DIFF
--- a/ClangDebug/makefile
+++ b/ClangDebug/makefile
@@ -54,7 +54,7 @@ all: monosat
 monosat: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C++ Linker'
-	clang++ -L../lib -o "monosat" $(OBJS) $(USER_OBJS) $(LIBS)
+	clang++  -o "monosat" $(OBJS) $(USER_OBJS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 

--- a/ClangDebug/objects.mk
+++ b/ClangDebug/objects.mk
@@ -4,5 +4,5 @@
 
 USER_OBJS :=
 
-LIBS := -lz -lm -lgmpxx -lgmp -ldl -lrt
+LIBS := -lz -lm -lgmpxx -lgmp -ldl
 

--- a/ClangRelease/objects.mk
+++ b/ClangRelease/objects.mk
@@ -4,5 +4,5 @@
 
 USER_OBJS :=
 
-LIBS := -lz -lm -lgmpxx -lgmp -ldl -lrt
+LIBS := -lz -lm -lgmpxx -lgmp -ldl
 

--- a/Debug/objects.mk
+++ b/Debug/objects.mk
@@ -4,5 +4,5 @@
 
 USER_OBJS :=
 
-LIBS := -lz -lm -lgmpxx -lgmp -lrt
+LIBS := -lz -lm -lgmpxx -lgmp
 

--- a/Release/makefile
+++ b/Release/makefile
@@ -54,7 +54,7 @@ all: monosat
 monosat: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C++ Linker'
-	g++ -L.././lib -o "monosat" $(OBJS) $(USER_OBJS) $(LIBS)
+	g++  -o "monosat" $(OBJS) $(USER_OBJS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 

--- a/Release/objects.mk
+++ b/Release/objects.mk
@@ -4,5 +4,5 @@
 
 USER_OBJS :=
 
-LIBS := -lz -lm -lgmpxx -lgmp -lrt
+LIBS := -lz -lm -lgmpxx -lgmp
 

--- a/SharedLibrary/makefile
+++ b/SharedLibrary/makefile
@@ -54,7 +54,7 @@ all: libmonosat.so
 libmonosat.so: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C++ Linker'
-	g++  -L.././lib -shared -o "libmonosat.so" $(OBJS) $(USER_OBJS) $(LIBS)
+	g++   -shared -o "libmonosat.so" $(OBJS) $(USER_OBJS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 

--- a/SharedLibrary/objects.mk
+++ b/SharedLibrary/objects.mk
@@ -4,5 +4,5 @@
 
 USER_OBJS :=
 
-LIBS := -lz -lm -lgmpxx -lgmp -lrt
+LIBS := -lz -lm -lgmpxx -lgmp
 

--- a/SharedLibraryDbg/makefile
+++ b/SharedLibraryDbg/makefile
@@ -54,7 +54,7 @@ all: libmonosat_dbg.so
 libmonosat_dbg.so: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C++ Linker'
-	g++  -L.././lib -shared -o "libmonosat_dbg.so" $(OBJS) $(USER_OBJS) $(LIBS)
+	g++  -shared -o "libmonosat_dbg.so" $(OBJS) $(USER_OBJS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 

--- a/SharedLibraryDbg/objects.mk
+++ b/SharedLibraryDbg/objects.mk
@@ -4,5 +4,5 @@
 
 USER_OBJS :=
 
-LIBS := -lz -lm -lgmpxx -lgmp -lrt
+LIBS := -lz -lm -lgmpxx -lgmp
 

--- a/Static/makefile
+++ b/Static/makefile
@@ -54,7 +54,7 @@ all: monosat
 monosat: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C++ Linker'
-	g++  -L.././lib -static-libgcc   -static-libstdc++  -static -Wl,-soname=libmonosat.so -o "monosat" $(OBJS) $(USER_OBJS) $(LIBS)
+	g++   -static-libgcc   -static-libstdc++  -static -Wl,-soname=libmonosat.so -o "monosat" $(OBJS) $(USER_OBJS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 

--- a/Static/objects.mk
+++ b/Static/objects.mk
@@ -4,5 +4,5 @@
 
 USER_OBJS :=
 
-LIBS := -lz -lm -lgmpxx -lgmp -lrt
+LIBS := -lz -lm -lgmpxx -lgmp
 

--- a/Win64SharedLibrary/makefile
+++ b/Win64SharedLibrary/makefile
@@ -54,7 +54,7 @@ all: monosat.dll
 monosat.dll: $(OBJS) $(USER_OBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C++ Linker'
-	x86_64-w64-mingw32-g++ -L.././lib -static   -static-libstdc++  -Wl,-no-undefined -Wl,--enable-runtime-pseudo-reloc -shared -Wl,-soname=monosat.dll -o "monosat.dll" $(OBJS) $(USER_OBJS) $(LIBS)
+	x86_64-w64-mingw32-g++  -static   -static-libstdc++  -Wl,-no-undefined -Wl,--enable-runtime-pseudo-reloc -shared -Wl,-soname=monosat.dll -o "monosat.dll" $(OBJS) $(USER_OBJS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 

--- a/Win64SharedLibrary/objects.mk
+++ b/Win64SharedLibrary/objects.mk
@@ -4,5 +4,5 @@
 
 USER_OBJS :=
 
-LIBS := -lz -lm -lgmpxx -lgmp -lrt
+LIBS := -lz -lm -lgmpxx -lgmp
 

--- a/api/Monosat.cpp
+++ b/api/Monosat.cpp
@@ -31,7 +31,9 @@
 using namespace Monosat;
 using namespace std;
 
-
+#ifdef __APPLE__
+using sighandler_t = sig_t;
+#endif
 
 //Supporting function for throwing parse errors
 inline void api_errorf(const char *fmt, ...) {
@@ -348,7 +350,7 @@ void readGNF(Monosat::SimpSolver * S, const char  * filename){
 
 }
 
-Monosat::GraphTheorySolver<int64_t> *  newGraph(Monosat::SimpSolver * S){
+Monosat::GraphTheorySolver<long> *  newGraph(Monosat::SimpSolver * S){
 	  MonosatData * d = (MonosatData*) S->_external_data;
 	  Monosat::GraphTheorySolver<long> *graph = new Monosat::GraphTheorySolver<long>(S);
 	  S->addTheory(graph);
@@ -362,7 +364,7 @@ Monosat::GraphTheorySolver<int64_t> *  newGraph(Monosat::SimpSolver * S){
 void backtrack(Monosat::SimpSolver * S){
 	S->cancelUntil(0);
 }
-Monosat::BVTheorySolver<int64_t> * initBVTheory(Monosat::SimpSolver * S){
+Monosat::BVTheorySolver<long> * initBVTheory(Monosat::SimpSolver * S){
 	MonosatData * d = (MonosatData*) S->_external_data;
 	if(d->bv_theory)
 		return d->bv_theory;

--- a/api/Monosat.h
+++ b/api/Monosat.h
@@ -14,9 +14,9 @@
 extern "C"
 {
 typedef Monosat::SimpSolver *  SolverPtr;
-typedef Monosat::GraphTheorySolver<int64_t> * GraphTheorySolver_long;
+typedef Monosat::GraphTheorySolver<long> * GraphTheorySolver_long;
 typedef Monosat::GraphTheorySolver<double>*  GraphTheorySolver_double;
-typedef Monosat::BVTheorySolver<int64_t>* BVTheoryPtr;
+typedef Monosat::BVTheorySolver<long>* BVTheoryPtr;
 typedef Monosat::FSMTheorySolver * FSMTheorySolverPtr;
 #else
 typedef void * SolverPtr;
@@ -100,17 +100,17 @@ typedef int Var;
   bool addTertiaryClause(SolverPtr S,int lit1, int lit2, int lit3);
   //theory interface for bitvectors
   BVTheoryPtr initBVTheory(SolverPtr S);
-  int newBitvector_const(SolverPtr S, BVTheoryPtr bv, int bvWidth, int64_t constval);
+  int newBitvector_const(SolverPtr S, BVTheoryPtr bv, int bvWidth, long constval);
   int newBitvector_anon(SolverPtr S, BVTheoryPtr bv, int bvWidth);
   int newBitvector(SolverPtr S, BVTheoryPtr bv, int * bits, int n_bits);
   int bv_width(SolverPtr S, BVTheoryPtr  bv,int bvID);
-  int newBVComparison_const_lt(SolverPtr S, BVTheoryPtr bv, int bvID, int64_t weight);
+  int newBVComparison_const_lt(SolverPtr S, BVTheoryPtr bv, int bvID, long weight);
   int newBVComparison_bv_lt(SolverPtr S, BVTheoryPtr bv, int bvID, int compareID);
-  int newBVComparison_const_leq(SolverPtr S, BVTheoryPtr bv, int bvID, int64_t weight);
+  int newBVComparison_const_leq(SolverPtr S, BVTheoryPtr bv, int bvID, long weight);
   int newBVComparison_bv_leq(SolverPtr S, BVTheoryPtr bv, int bvID, int compareID);
-  int newBVComparison_const_gt(SolverPtr S, BVTheoryPtr bv, int bvID, int64_t weight);
+  int newBVComparison_const_gt(SolverPtr S, BVTheoryPtr bv, int bvID, long weight);
   int newBVComparison_bv_gt(SolverPtr S, BVTheoryPtr bv, int bvID, int compareID);
-  int newBVComparison_const_geq(SolverPtr S, BVTheoryPtr bv, int bvID, int64_t weight);
+  int newBVComparison_const_geq(SolverPtr S, BVTheoryPtr bv, int bvID, long weight);
   int newBVComparison_bv_geq(SolverPtr S, BVTheoryPtr bv, int bvID, int compareID);
 
 
@@ -141,22 +141,22 @@ typedef int Var;
   GraphTheorySolver_long newGraph(SolverPtr S);
 
   int newNode(SolverPtr S,GraphTheorySolver_long G);
-  int newEdge(SolverPtr S, GraphTheorySolver_long G,int from,int  to,  int64_t weight);
+  int newEdge(SolverPtr S, GraphTheorySolver_long G,int from,int  to,  long weight);
   int newEdge_double(SolverPtr S, GraphTheorySolver_double G,int from,int  to,  double weight);
   int newEdge_bv(SolverPtr S, GraphTheorySolver_long G,int from,int  to, int bvID);
   int reaches(SolverPtr S,GraphTheorySolver_long G,int from, int to);
   int shortestPathUnweighted_lt_const(SolverPtr S,GraphTheorySolver_long G,int from, int to, int steps);
   int shortestPathUnweighted_leq_const(SolverPtr S,GraphTheorySolver_long G,int from, int to, int steps);
-  int shortestPath_lt_const(SolverPtr S,GraphTheorySolver_long G,int from, int to, int64_t dist);
-  int shortestPath_leq_const(SolverPtr S,GraphTheorySolver_long G,int from, int to, int64_t dist);
+  int shortestPath_lt_const(SolverPtr S,GraphTheorySolver_long G,int from, int to, long dist);
+  int shortestPath_leq_const(SolverPtr S,GraphTheorySolver_long G,int from, int to, long dist);
   int shortestPath_lt_bv(SolverPtr S,GraphTheorySolver_long G,int from, int to, int bvID);
   int shortestPath_leq_bv(SolverPtr S,GraphTheorySolver_long G,int from, int to, int bvID);
-  int maximumFlow_geq(SolverPtr S,GraphTheorySolver_long G,int source, int sink, int64_t weight);
-  int maximumFlow_gt(SolverPtr S,GraphTheorySolver_long G,int source, int sink, int64_t weight);
+  int maximumFlow_geq(SolverPtr S,GraphTheorySolver_long G,int source, int sink, long weight);
+  int maximumFlow_gt(SolverPtr S,GraphTheorySolver_long G,int source, int sink, long weight);
   int maximumFlow_geq_bv(SolverPtr S,GraphTheorySolver_long G,int source, int sink, int bvID);
   int maximumFlow_gt_bv(SolverPtr S,GraphTheorySolver_long G,int source, int sink, int bvID);
-  int minimumSpanningTree_leq(SolverPtr S,GraphTheorySolver_long G, int64_t weight);
-  int minimumSpanningTree_lt(SolverPtr S,GraphTheorySolver_long G,int source, int sink, int64_t weight);
+  int minimumSpanningTree_leq(SolverPtr S,GraphTheorySolver_long G, long weight);
+  int minimumSpanningTree_lt(SolverPtr S,GraphTheorySolver_long G,int source, int sink, long weight);
   int acyclic_undirected(SolverPtr S,GraphTheorySolver_long G);
   int acyclic_directed(SolverPtr S,GraphTheorySolver_long G);
 
@@ -174,15 +174,15 @@ typedef int Var;
   int getModel_Literal(SolverPtr S,int lit);
   //Get an assignment to a bitvector in the model. The model may find a range of satisfying assignments to the bitvector;
   //If getMaximumValue is true, this function returns the maximum satisfying assignment to the bitvector in the model; else it returns the smallest.
-  int64_t getModel_BV(SolverPtr S, BVTheoryPtr bv, int bvID, bool getMaximumValue);
+  long getModel_BV(SolverPtr S, BVTheoryPtr bv, int bvID, bool getMaximumValue);
   //graph queries:
   //maxflow_literal is the literal (not variable!) that is the atom for the maximum flow query
-  int64_t getModel_MaxFlow(SolverPtr S,GraphTheorySolver_long G,int maxflow_literal);
+  long getModel_MaxFlow(SolverPtr S,GraphTheorySolver_long G,int maxflow_literal);
   //maxflow_literal is the literal (not variable!) that is the atom for the maximum flow query
-  int64_t getModel_EdgeFlow(SolverPtr S,GraphTheorySolver_long G,int maxflow_literal, int edgeLit);
-  int64_t getModel_AcyclicEdgeFlow(SolverPtr S,GraphTheorySolver_long G,int maxflow_literal, int edgeLit);
+  long getModel_EdgeFlow(SolverPtr S,GraphTheorySolver_long G,int maxflow_literal, int edgeLit);
+  long getModel_AcyclicEdgeFlow(SolverPtr S,GraphTheorySolver_long G,int maxflow_literal, int edgeLit);
 
-  int64_t getModel_MinimumSpanningTreeWeight(SolverPtr S,GraphTheorySolver_long G,int spanning_tree_literal);
+  long getModel_MinimumSpanningTreeWeight(SolverPtr S,GraphTheorySolver_long G,int spanning_tree_literal);
 /*
   //Returns the number of nodes in the path length for this reachability or shortest path literal (1+number of edges)
   int getModel_PathLength(SolverPtr S,GraphTheorySolver_long G,int reach_or_shortest_path_lit);

--- a/api/python/monosat/monosat_c.py
+++ b/api/python/monosat/monosat_c.py
@@ -195,12 +195,21 @@ class Monosat(metaclass=Singleton):
         self.monosat_c.newBVComparison_bv_lt.argtypes=[c_solver_p,c_bv_p,c_bvID, c_bvID]
         self.monosat_c.newBVComparison_bv_lt.restype=c_literal
         
+        self.monosat_c.newBVComparison_const_leq.argtypes=[c_solver_p,c_bv_p,c_bvID, c_long]
+        self.monosat_c.newBVComparison_const_leq.restype=c_literal
+
         self.monosat_c.newBVComparison_bv_leq.argtypes=[c_solver_p,c_bv_p,c_bvID, c_bvID]
         self.monosat_c.newBVComparison_bv_leq.restype=c_literal
         
+        self.monosat_c.newBVComparison_const_gt.argtypes=[c_solver_p,c_bv_p,c_bvID, c_long]
+        self.monosat_c.newBVComparison_const_gt.restype=c_literal
+
         self.monosat_c.newBVComparison_bv_gt.argtypes=[c_solver_p,c_bv_p,c_bvID, c_bvID]
         self.monosat_c.newBVComparison_bv_gt.restype=c_literal
         
+        self.monosat_c.newBVComparison_const_geq.argtypes=[c_solver_p,c_bv_p,c_bvID, c_long]
+        self.monosat_c.newBVComparison_const_geq.restype=c_literal
+
         self.monosat_c.newBVComparison_bv_geq.argtypes=[c_solver_p,c_bv_p,c_bvID, c_bvID]
         self.monosat_c.newBVComparison_bv_geq.restype=c_literal
         

--- a/api/python/monosat/monosat_c.py
+++ b/api/python/monosat/monosat_c.py
@@ -24,13 +24,17 @@ from os import path
 from monosat.singleton import Singleton
 
 import os
-#module_path = os.path.abspath(path.dirname(__file__))
-try:
-    _monosat_c= cdll.LoadLibrary("libmonosat.so")
-except Exception as e:
-    print (e)
+import platform
 
-    _monosat_c= cdll.LoadLibrary('monosat.dll')
+module_path = os.path.abspath(path.dirname(__file__))
+library_monosat = "libmonosat.so"
+if platform.system() == 'Windows':
+    library_monosat = "libmonosat.dll"
+try:
+    _monosat_c= cdll.LoadLibrary(os.path.join(module_path, library_monosat))
+except Exception as e:
+    print ("Unable to load libmonosat dynamic library")
+    raise e
 
 #Python interface to MonoSAT
     

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -2,7 +2,7 @@
 
 from distutils.core import setup
 
-setup(name='Distutils',
+setup(name='monosat',
       version='1.0',
       description='MonoSAT Python Interface',
       author='Sam Bayless',

--- a/api/python/setup.py
+++ b/api/python/setup.py
@@ -2,6 +2,18 @@
 
 from distutils.core import setup
 
+import os.path
+import shutil
+import platform
+
+if platform.system != "Windows":
+    copy_lib = "monosat/libmonosat.so"
+    orig_lib = "../../SharedLibrary/libmonosat.so"
+    if not os.path.exists(copy_lib):
+        shutil.copy2(orig_lib, "monosat")
+    if os.path.getmtime(orig_lib) > os.path.getmtime(copy_lib):
+        shutil.copy2(orig_lib, "monosat")
+
 setup(name='monosat',
       version='1.0',
       description='MonoSAT Python Interface',
@@ -9,4 +21,5 @@ setup(name='monosat',
       author_email='sbayless@cs.ubc.ca',
       url='http://www.cs.ubc.ca/labs/isd/Projects/monosat/',
       packages=['monosat'],
+      package_data={'monosat': ['libmonosat.so']},
      )

--- a/utils/ParseUtils.h
+++ b/utils/ParseUtils.h
@@ -23,6 +23,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string>
 
 #include <zlib.h>
 #include "mtl/Vec.h"

--- a/utils/System.h
+++ b/utils/System.h
@@ -40,7 +40,7 @@ extern double memUsedPeak();        // Peak-memory in mega bytes (returns 0 for 
 //-------------------------------------------------------------------------------------------------
 // Implementation of inline functions:
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__APPLE__)
 #include <time.h>
 
 static inline double Monosat::cpuTime(void) {return (double)clock() / CLOCKS_PER_SEC;}


### PR DESCRIPTION
Please find enclosed a fix for compilation under OSX (`clang` compiler)
The current version still compiles ok under Ubuntu.

About the corrections:
- makefiles (*seems generated, you might want to fix something uphill...*):
  - `-L../lib`: the directory does not exist, `clang` fails
  - `-lrt` does not seem necessary under Ubuntu; besides, the library is not implemented in OSX.
- in the source files:
  - `sighandler_t` does not exist in OSX, but the proposed fix works fine
  - `int64_t` is **not** equivalent to `long` under OSX (or Windows), see this [gist](https://gist.github.com/xoolive/7b2fdc7dd561e0f5058d)
  - similar issues with `time.h`, fixed by falling back to the Windows switch
  - missing include of `<string>` caused compilation to fail with `clang`
- in the Python API:
  - some signatures were missing causing the `bitvalue` theory to segfault (except with operator `<`). All tests pass ok now.
  - I do not have permission to write in my `/usr/local/lib` (and use `virtualenv` for packages): I added some lines in `setup.py` and in the loading of the `libmonosat.so` in order to ship the DLL with the package. (which is somehow cleaner if you want to keep several versions, like `stable`, `dev`, etc.)

Now it works :smile: 