### PR TITLE
Add <stdexcept> include

### DIFF
--- a/src/monosat/dgl/DynamicGraph.h
+++ b/src/monosat/dgl/DynamicGraph.h
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <cstdint>
 #include <sstream>
+#include <stdexcept>
 #include <cstdio>
 #include "Graph.h"
 


### PR DESCRIPTION
This file fails to build on my machine with gcc 4.9.  This change gets the build to go through.