### PR TITLE
distutils -> setuptools

### DIFF
--- a/src/monosat/api/python/setup.py
+++ b/src/monosat/api/python/setup.py
@@ -5,7 +5,7 @@ import os.path
 import platform
 import shutil
 import sys
-from distutils.core import setup
+from setuptools import setup
 
 if sys.version_info[0] < 3:
     sys.exit('Sorry, Python < 3 is not supported')


### PR DESCRIPTION
Fixes the "Unknown distribution option: 'install_requires'" error while running `make install`. 

distribute is deprecated according to http://pythonhosted.org/distribute/:

    Distribute is a deprecated fork of the Setuptools project.

    Since the Setuptools 0.7 release, Setuptools and Distribute have merged and
    Distribute is no longer being maintained. All ongoing effort should reference the
    Setuptools project and the Setuptools documentation.

