### PR TITLE
Quick bugfix for addUndirectedEdge(int,int), to be checked and tested

### DIFF
--- a/src/monosat/api/java/monosat/Graph.java
+++ b/src/monosat/api/java/monosat/Graph.java
@@ -846,7 +846,7 @@ public final class Graph {
    * @return The literal that controls whether this edge is included in the graph.
    */
   public Lit addUndirectedEdge(int from, int to, long constantWeight) {
-    return addUndirectedEdge(from,to,constantWeight);
+    return addUndirectedEdge(from,to,constantWeight,"");
   }
   /**
    * Add a new undirected edge to the graph, from node 'from' to node 'to', with a constant weight.
@@ -873,7 +873,8 @@ public final class Graph {
       Lit l2 = addEdge(to, from, constantWeight);
       solver.assertEqual(l, l2);
       getSolver().addName(l,name);
-      getSolver().addName(l2,name+"_back");
+      //getSolver().addName(l2,name+"_back");
+      getSolver().addName(l2,name);
       return l;
     }
   }
@@ -918,7 +919,8 @@ public final class Graph {
     Lit l2 = addEdge(to, from, weight);
     solver.assertEqual(l, l2);
     getSolver().addName(l,name);
-    getSolver().addName(l2,name+"_back");
+    //getSolver().addName(l2,name+"_back");
+    getSolver().addName(l2,name);
     return l;
   }
 


### PR DESCRIPTION
Calling Graph.addUndiretedEdge(int,int) gives me a buffer overflow error.
The implementation seems to call itself recursively (see line 849 of Graph.java).
The naming of the "reversed" edge seems to create problems, too (line 873 and line 921 of Graph.java).

These changes fix my problems, but I spent only a very limited time on this, please check them and apologies in advance if I missed some important point... :-)

Thanks!

