### PR TITLE
Update to work with Python 3.8

### DIFF
--- a/examples/python/nqueens.py
+++ b/examples/python/nqueens.py
@@ -42,7 +42,7 @@ def print_matrix():
             print_cell(row, col)
     print()
 
-time_start_gen = time.clock()
+time_start_gen = time.process_time()
 
 # a matrix storing variables
 QMATRIX = [[Var() for x in range(nb_queens)] for x in range(nb_queens)]
@@ -93,13 +93,13 @@ for row in range(nb_queens):
                 print('~({0}, {1}), ~({2}, {3})'.format(row, col, row-x, col-x))
             AssertClause([Not(QMATRIX[row][col]), Not(QMATRIX[row+x][col-x])])
 
-time_end_gen = time.clock()
+time_end_gen = time.process_time()
 
-time_start_solve = time.clock()
+time_start_solve = time.process_time()
 
 result = Solve()
 
-time_end_solve = time.clock()
+time_end_solve = time.process_time()
 
 if result:
     print_matrix()

--- a/src/monosat/api/python/monosat/pbtheory.py
+++ b/src/monosat/api/python/monosat/pbtheory.py
@@ -1092,7 +1092,7 @@ class MinisatPlus:
             )
 
         print("Importing %d pseudoboolean constraints into Monosat..." % (n_pbs))
-        t = time.clock()
+        t = time.process_time()
 
         Monosat().comment("pseudoboolean constraints")
         n_cls = 0
@@ -1131,7 +1131,7 @@ class MinisatPlus:
 
         os.remove(tmpopb)
         os.remove(tmpcnf)
-        PBManager().import_time += time.clock() - t
+        PBManager().import_time += time.process_time() - t
         print("Imported pseudoboolean constraints into Monosat (%d clauses)" % (n_cls))
 
 

--- a/src/monosat/api/python/monosat/solver.py
+++ b/src/monosat/api/python/monosat/solver.py
@@ -35,7 +35,7 @@ def Solve(
     # if preprocessing:
     #    Monosat().preprocess();
     # print("Solving in Monosat...")
-    t = time.clock()
+    t = time.process_time()
 
     if isinstance(assumptions, Var):
         assumptions = [assumptions]
@@ -62,7 +62,7 @@ def Solve(
         raise SolveException(
             "MonoSAT aborted before solving (possibly do to a time or memory limit)"
         )
-    Monosat().elapsed_time += time.clock() - t
+    Monosat().elapsed_time += time.process_time() - t
     found_optimal = Monosat().lastSolutionWasOptimal()
     if r is None:
         raise SolveException(
@@ -148,8 +148,8 @@ def _writePBCosntraints():
     if not PBManager().hasConstraints():
         return
 
-    t = time.clock()
+    t = time.process_time()
     pbmgr = PBManager()
     pbmgr.flush()
-    d = time.clock()
+    d = time.process_time()
     PBManager().elapsed_time += d - t


### PR DESCRIPTION
`time.clock` has been removed in Python 3.8: https://docs.python.org/3.7/library/time.html#time.clock

`process_time` matches what `clock` used to do on Unix.

