### PR TITLE
Fix an integer overflow issue with the dynamic cut algorithm. 

### DIFF
--- a/src/monosat/dgl/alg/dyncut/graph.h
+++ b/src/monosat/dgl/alg/dyncut/graph.h
@@ -381,7 +381,7 @@ private:
         arc* parent = nullptr;    // node's parent
         node* next = nullptr;        // pointer to the next active node
         //   (or to itself if it is the last node in the list)
-        int TS = 0;        // timestamp showing when DIST was computed
+        u_int64_t TS = 0;        // timestamp showing when DIST was computed
         int DIST = 0;        // distance to the terminal
         int is_sink :1;    // flag showing whether the node is in the source or in the sink tree (if parent!=NULL)
         int is_marked :1;    // set by mark_node()
@@ -433,7 +433,7 @@ private:
 
     node* queue_first[2], * queue_last[2];    // list of active nodes
     nodeptr* orphan_first = nullptr, * orphan_last = nullptr;        // list of pointers to orphans
-    int TIME = 0;                    // monotonically increasing global counter
+    u_int64_t TIME = 0;                    // monotonically increasing global counter
 
     /////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Fix an integer overflow issue with the dynamic cut algorithm.  Currently, the solver uses an int type TIME variable to stamp node's in the dynamic search tree when computing nodes' distance to terminals. However, after a while, TIME will overflow and  will evenutally stamp nodes with negative value. This problem may cause the search tree to form cycles, and stops solving from progressing.

The proposed fix is to change the type of TIME from int to u_int64_t.