### PR TITLE
Fix an issue of parsing negative external variable 

### DIFF
--- a/src/monosat/bv/BVParser.h
+++ b/src/monosat/bv/BVParser.h
@@ -424,6 +424,11 @@ private:
         skipWhitespace(in);
         int v_int = parseInt(in);
 
+        if(v_int < 0){
+            v_int = -v_int;
+            isEquality = !isEquality;
+        }
+
         v_int = v_int - 1;
         Var v = (Var) v_int;
         if(this->inVarMap((Var) v_int))
@@ -480,6 +485,11 @@ private:
 
         skipWhitespace(in);
         int v_int = parseInt(in);
+        
+        if(v_int < 0){
+            v_int = -v_int;
+            isEquality = !isEquality;
+        }
 
         v_int = v_int - 1;
         Var v = (Var) v_int;


### PR DESCRIPTION
Monosat could run into segmentation faults when parsing BV equality predicate atoms with negative external variables.

For example:
bv const != -20 x y

MonoSAT checks wether the external variable (-20) already exists or not by calling:

inline bool inVarMap(Var externalVar){
        if(externalVar == var_Undef){
            return false;
        }
        return externalVar < var_map.size() && **var_map[externalVar] != var_Undef**;
    }

where var_map is accessed with a negative index.

To fix this issue, if the external variable x is negative , we can process -x instead. Doing so would require flipping the sign for equality (inequality).

Thank you,
Nick 





